### PR TITLE
General improvements to logging

### DIFF
--- a/302.go
+++ b/302.go
@@ -44,23 +44,29 @@ type Config struct {
 	LogDirectory      string `json:"log-directory"`
 }
 
-var logger = loggo.GetLogger("mirrorzd") // to stderr
-var resolveLogger loggo.Logger
-var failLogger loggo.Logger
-var cacheGCLogger loggo.Logger
-var config Config
+type Logger struct {
+	loggo.Logger
+	f *os.File
+}
 
-var client influxdb2.Client
-var queryAPI api.QueryAPI
+var (
+	logger        = loggo.GetLogger("mirrorzd") // to stderr
+	resolveLogger Logger
+	failLogger    Logger
+	cacheGCLogger Logger
+	config        Config
+
+	client   influxdb2.Client
+	queryAPI api.QueryAPI
+)
 
 func LoggerFileFormatter(entry loggo.Entry) string {
 	ts := entry.Timestamp.In(time.UTC).Format("2006-01-02 15:04:05")
 	return fmt.Sprintf("%s %s", ts, entry.Message)
 }
 
-func InitLogger(filename string) (logger loggo.Logger, err error) {
-	context := loggo.NewContext(loggo.INFO) // TODO: configurable
-	// Note: how about old file when reload via USR2 (e.g. logrotate)
+func (l *Logger) Open(filename string, level loggo.Level) (err error) {
+	context := loggo.NewContext(level)
 	logfile := path.Join(config.LogDirectory, filename)
 	f, err := os.OpenFile(logfile, os.O_CREATE|os.O_RDWR|os.O_APPEND, os.ModeAppend|0600)
 	if err != nil {
@@ -70,25 +76,35 @@ func InitLogger(filename string) (logger loggo.Logger, err error) {
 	if err != nil {
 		return
 	}
-	logger = context.GetLogger("default")
+	l.Logger = context.GetLogger("default")
+	err = l.f.Close()
+	l.f = f
+	return
+}
+
+func (l *Logger) Close() (err error) {
+	if l.f != nil {
+		err = l.f.Close()
+		l.f = nil
+	}
 	return
 }
 
 func InitLoggers() (err error) {
 	// global resolveLogger
-	resolveLogger, err = InitLogger("resolve.log")
+	err = resolveLogger.Open("resolve.log", loggo.INFO)
 	if err != nil {
 		return
 	}
 
 	// global failLogger
-	failLogger, err = InitLogger("fail.log")
+	err = failLogger.Open("fail.log", loggo.INFO)
 	if err != nil {
 		return
 	}
 
 	// global cacheGCLogger
-	cacheGCLogger, err = InitLogger("gc.log")
+	err = cacheGCLogger.Open("gc.log", loggo.INFO)
 	if err != nil {
 		return
 	}
@@ -150,7 +166,7 @@ func LoadConfig(path string, debug bool) (err error) {
 	}
 	// If you changed LogDirectory via SIGUSR1, you should issue SIGUSR2 manually
 	if config.LogDirectory == "" {
-		config.LogDirectory = "/var/log/mirrorzd/"
+		config.LogDirectory = "/var/log/mirrorzd"
 	}
 	logger.Debugf("LoadConfig InfluxDB URL: %s\n", config.InfluxDBURL)
 	logger.Debugf("LoadConfig InfluxDB Org: %s\n", config.InfluxDBOrg)

--- a/302.go
+++ b/302.go
@@ -92,20 +92,17 @@ func (l *Logger) Close() (err error) {
 
 func InitLoggers() (err error) {
 	// global resolveLogger
-	err = resolveLogger.Open("resolve.log", loggo.INFO)
-	if err != nil {
+	if err = resolveLogger.Open("resolve.log", loggo.INFO); err != nil {
 		return
 	}
 
 	// global failLogger
-	err = failLogger.Open("fail.log", loggo.INFO)
-	if err != nil {
+	if err = failLogger.Open("fail.log", loggo.INFO); err != nil {
 		return
 	}
 
 	// global cacheGCLogger
-	err = cacheGCLogger.Open("gc.log", loggo.INFO)
-	if err != nil {
+	if err = cacheGCLogger.Open("gc.log", loggo.INFO); err != nil {
 		return
 	}
 


### PR DESCRIPTION
- Change string concat to `path.Join()`
- Support log level in `(*Logger).Open()`
- Close previous file handle on reopening file