### PR TITLE
Feat: add granular range setting

### DIFF
--- a/302.go
+++ b/302.go
@@ -58,7 +58,10 @@ func main() {
 	}
 
 	if config.IPDBFile != "" {
-		geo.LoadIPDB(config.IPDBFile)
+		if err := geo.LoadIPDB(config.IPDBFile); err != nil {
+			logger.Errorf("Cannot load IPDB file: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	s := server.NewServer(config)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In 302-go, users are redirected to a mirror site based on their IP, ISP, geoloca
 * mirror site
   - endpoint: multiple upstreams (CERNET, CMNET, etc), ipv4/ipv6 only endpoint, and default endpoint
   - range: users inside this range should better be redirected to this mirror site
-  - public: private mirror has limited access range. a private mirror must define range in CIDR, ISP, or REGION. If no range is defined, the mirror is treated as disabled and will not serve any request.
+  - public: private mirror has limited access range, IP not in its CIDR range should not be redirected there. A private mirror must declare at least one CIDR in `range`, otherwise it is treated as disabled.
 * operator (not implemented)
   - load balance
   - speed testing from multiple AS
@@ -75,12 +75,7 @@ freshness are supplied separately by mirrorz-monitor through InfluxDB.
       "label": "ustccampus",
       "public": false,
       "resolve": "10.0.0.1:8080/proxy",
-      "filter": [ 
-        "V4",
-        "NOSSL",
-        "REGION:AH",
-        "ISP:CERNET"
-      ],
+      "filter": [ "V4", "NOSSL" ],
       "range": [
         "202.0.0.0/24",
         "2001:da8::/32"
@@ -97,6 +92,10 @@ freshness are supplied separately by mirrorz-monitor through InfluxDB.
   - `resolve`: a domain name or IP address. This is directly concatenated in the final URL so a subpath may also be provided (e.g. `linux.xidian.edu.cn/mirrors` and `10.0.0.1:8080/proxy`).
     + It should not end with slash `/` as the request path `/archlinux/iso` will be directly concatenated to it.
   - `public`: the endpoint can be reached outside of its range. Usually `false` for campus-only mirrors. When `public: false` and `range` declares no CIDR, the endpoint is treated as disabled and never serves any request.
+  - `private_range` Used **only when `public` is `false`**. It controls access when the client IP does **not** match any CIDR in `range`.
+    - **Format**: `[["REGION:...", "ISP:..."], ...]` (a 2D string array).
+    - Each inner array is a **group**; all specified conditions inside must match (logical **AND**).
+    - The request is allowed if **any** group matches (logical **OR**); otherwise denied.
   - `filter`: Each endpoint has many capabilities
     + `SSL`: HTTPS available
     + `NOSSL`: HTTP available, and does not redirect to HTTPS when accessing repos
@@ -169,30 +168,25 @@ If a user does not match any range or match exactly the same in `mirrors` and `m
 #### On range when private endpoint
 
 ```json
-{
-  "label": "ustccampus",
+  {
+  "label": "zju",
   "public": false,
-  "resolve": "10.0.0.1:8080/proxy",
-  "filter": [
-    "V4",
-    "NOSSL",
-    "REGION:AH",
-    "ISP:CERNET"
+  "resolve": "mirrors.zju.edu.cn",
+  "filter": ["V4", "V6", "SSL", "NOSSL"],
+  "private_range": [
+    ["REGION:ZJ"]
   ],
   "range": [
-    "202.0.0.0/24",
-    "2001:da8::/32"
+    "COUNTRY:CN",
+    "REGION:ZJ",
+    "210.32.0.0/20",
+    "some other CIDR"
   ]
 }
 ```
-* `public`: the endpoint can be reached outside of its range. Usually `false` for campus‑only mirrors. For private endpoints (`public: false`), access is restricted and follows the sequential rules below:
+The site may use `private_range` to control access for users outside of its `range`. when `public` is `false`, the endpoint will only serve users whose IP falls in its `range`. For users outside CIDRs in `range`, it will check if they match any group in `private_range`. If yes, then the request is allowed; otherwise denied.
+As follows, a user from Zhejiang will be possible to be redirected to this endpoint, while a user from Shanghai will be denied.
 
-  1. **CIDR priority** – if any CIDR is declared in `range` and the client IP matches one of them, the endpoint is allowed (this takes precedence over all other checks).
-  2. **Filter (AND)** – if the IP does NOT match any CIDR, and `filter` contains `REGION` or `ISP` conditions, then all such conditions must match (AND) for the endpoint to be allowed. If they match, access is granted without examining `range` further.
-  3. **Range (OR)** – if `filter` contains NO `REGION`/`ISP`, but `range` contains `REGION` or `ISP`, then at least one of those must match (OR) for the endpoint to be allowed.
-  4. **Disabled** – if NO CIDR matched, and NO `REGION`/`ISP` is defined in either `filter` or `range`, the endpoint is considered disabled and will never serve the request.
-
-ISP and REGION in `filter` only affect access for private endpoints.
 #### TODO
 
 **Advanced** user can explicitly annouce their capability in their request like `http://ssl.mirrors.edu.cn`, then we must redirect it to a https site. Some interesting usage like `https://sjtug-nossl-wsyu-ssl-ustc-tuna.mirrors.edu.cn`, namely no preference (http and https both ok) for sjtug, use http endpoint for wsyu, and force ssl for ustc and tuna.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In 302-go, users are redirected to a mirror site based on their IP, ISP, geoloca
 * mirror site
   - endpoint: multiple upstreams (CERNET, CMNET, etc), ipv4/ipv6 only endpoint, and default endpoint
   - range: users inside this range should better be redirected to this mirror site
-  - public: private mirror has limited access range, IP not in its CIDR range should not be redirected there. A private mirror must declare at least one CIDR in `range`, otherwise it is treated as disabled.
+  - public: private mirror has limited access range. a private mirror must define range in CIDR, ISP, or REGION. If no range is defined, the mirror is treated as disabled and will not serve any request.
 * operator (not implemented)
   - load balance
   - speed testing from multiple AS
@@ -75,7 +75,12 @@ freshness are supplied separately by mirrorz-monitor through InfluxDB.
       "label": "ustccampus",
       "public": false,
       "resolve": "10.0.0.1:8080/proxy",
-      "filter": [ "V4", "NOSSL" ],
+      "filter": [ 
+        "V4",
+        "NOSSL",
+        "REGION:AH",
+        "ISP:CERNET"
+      ],
       "range": [
         "202.0.0.0/24",
         "2001:da8::/32"
@@ -164,17 +169,30 @@ If a user does not match any range or match exactly the same in `mirrors` and `m
 #### On range when private endpoint
 
 ```json
-    {
-      "label": "ustccampus",
-      "public": false,
-      "resolve": "10.0.0.1:8080",
-      "filter": [ "V4", "NOSSL" ],
-      "range": [ "202.0.0.0/24" ]
-    },
+{
+  "label": "ustccampus",
+  "public": false,
+  "resolve": "10.0.0.1:8080/proxy",
+  "filter": [
+    "V4",
+    "NOSSL",
+    "REGION:AH",
+    "ISP:CERNET"
+  ],
+  "range": [
+    "202.0.0.0/24",
+    "2001:da8::/32"
+  ]
+}
 ```
+* `public`: the endpoint can be reached outside of its range. Usually `false` for campus‑only mirrors. For private endpoints (`public: false`), access is restricted and follows the sequential rules below:
 
-Campus-only mirror site may use a private IP but declare a public range. For example, suppose USTC has a private IP range of 10.0.0.0/8, USTC mirror is located at 10.0.0.1:8080, and when one user inside USTC accesses `mirrors.edu.cn`, its IP is NATed into 202.0.0.0/24, then `mirrors.edu.cn` can resolve the request into `ustccampus` endpoint.
+  1. **CIDR priority** – if any CIDR is declared in `range` and the client IP matches one of them, the endpoint is allowed (this takes precedence over all other checks).
+  2. **Filter (AND)** – if the IP does NOT match any CIDR, and `filter` contains `REGION` or `ISP` conditions, then all such conditions must match (AND) for the endpoint to be allowed. If they match, access is granted without examining `range` further.
+  3. **Range (OR)** – if `filter` contains NO `REGION`/`ISP`, but `range` contains `REGION` or `ISP`, then at least one of those must match (OR) for the endpoint to be allowed.
+  4. **Disabled** – if NO CIDR matched, and NO `REGION`/`ISP` is defined in either `filter` or `range`, the endpoint is considered disabled and will never serve the request.
 
+ISP and REGION in `filter` only affect access for private endpoints.
 #### TODO
 
 **Advanced** user can explicitly annouce their capability in their request like `http://ssl.mirrors.edu.cn`, then we must redirect it to a https site. Some interesting usage like `https://sjtug-nossl-wsyu-ssl-ustc-tuna.mirrors.edu.cn`, namely no preference (http and https both ok) for sjtug, use http endpoint for wsyu, and force ssl for ustc and tuna.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ freshness are supplied separately by mirrorz-monitor through InfluxDB.
   - `label`: a unique identifier for this endpoint
   - `resolve`: a domain name or IP address. This is directly concatenated in the final URL so a subpath may also be provided (e.g. `linux.xidian.edu.cn/mirrors` and `10.0.0.1:8080/proxy`).
     + It should not end with slash `/` as the request path `/archlinux/iso` will be directly concatenated to it.
-  - `public`: the endpoint can be reached outside of its range. Usually `false` for campus-only mirrors. When `public: false` and `range` declares no CIDR, the endpoint is treated as disabled and never serves any request.
-  - `private_range` Used **only when `public` is `false`**. It controls access when the client IP does **not** match any CIDR in `range`.
+  - `public`: when `true`, `range` only affects preference scoring. When `false`, matching CIDR entries in `range` can access it, and users outside those CIDRs may still be allowed by `private_range`. If `range` has no CIDR, access is determined by `private_range`.
+  - `private_range`: used **only when `public` is `false`**. It controls access for clients whose IP does **not** match any CIDR in `range`, and can also be the only access rule when `range` has no CIDR.
     - **Format**: `[["REGION:...", "ISP:..."], ...]` (a 2D string array).
     - Each inner array is a **group**; all specified conditions inside must match (logical **AND**).
     - The request is allowed if **any** group matches (logical **OR**); otherwise denied.
@@ -101,7 +101,7 @@ freshness are supplied separately by mirrorz-monitor through InfluxDB.
     + `NOSSL`: HTTP available, and does not redirect to HTTPS when accessing repos
     + `V4`: IPv4 available (A record)
     + `V6`: IPv6 available (AAAA record)
-  - `range`: when `public`, the endpoint **prefers** these ranges, other user may still use this endpoint; otherwise it **only serves** clients whose IP falls in one of the declared CIDRs. ISP and REGION do not grant access for private endpoints (they are only used for preference scoring when `public`). If no CIDR is declared, the endpoint is disabled.
+  - `range`: when `public` is `true`, the endpoint **prefers** these ranges more strongly, but other users may still use this endpoint; when `public` is `false`, CIDR entries still allow access, while `ISP` and `REGION` do not. `ISP` and `REGION` are only effective inside `private_range`. If no CIDR is declared, `private_range` may still allow access.
     + COUNTRY: Must start with `COUNTRY`, then a colon, then [ISO country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Example: `COUNTRY:CN` or `COUNTRY:US`. Defaults to `CN`.
     + REGION: Must start with `REGION`, then a colon, then province name (GB/T 2260-2007). Example: `REGION:BJ` (Beijing) or `REGION:SH` (Shanghai). Defaults to `BJ`.
     + ISP: Must start with `ISP`, then a colon, then ISP name. Example: `ISP:CERNET` or `ISP:CHINANET`. Defaults to `CERNET`. All currently supported values are `CERNET`, `CSTNET`, `CHINANET`, `UNICOM` and `CMCC`.
@@ -184,7 +184,7 @@ If a user does not match any range or match exactly the same in `mirrors` and `m
   ]
 }
 ```
-The site may use `private_range` to control access for users outside of its `range`. when `public` is `false`, the endpoint will only serve users whose IP falls in its `range`. For users outside CIDRs in `range`, it will check if they match any group in `private_range`. If yes, then the request is allowed; otherwise denied.
+The site may use `private_range` to control access for users outside of its CIDR `range`. when `public` is `false`, CIDR matches are allowed directly. If `range` has no CIDR, access is decided by `private_range`. For users outside CIDRs in `range`, it will check if they match any group in `private_range`. If yes, then the request is allowed; otherwise denied.
 As follows, a user from Zhejiang will be possible to be redirected to this endpoint, while a user from Shanghai will be denied.
 
 #### TODO

--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ freshness are supplied separately by mirrorz-monitor through InfluxDB.
       "resolve": "chinanet.mirrors.ustc.edu.cn",
       "filter": [ "V4", "SSL", "NOSSL" ],
       "range": [
-        "AS4134",
-        "AS4809",
         "REGION:AH",
         "ISP:CHINANET"
       ]
@@ -96,16 +94,16 @@ freshness are supplied separately by mirrorz-monitor through InfluxDB.
     - **Format**: `[["REGION:...", "ISP:..."], ...]` (a 2D string array).
     - Each inner array is a **group**; all specified conditions inside must match (logical **AND**).
     - The request is allowed if **any** group matches (logical **OR**); otherwise denied.
+    - Each group may contain at most one `REGION` and one `ISP`. Empty groups, empty values, duplicate conditions, and unknown condition types make the site configuration invalid.
+    - REGION/ISP access requires a successful lookup from a loaded IPDB. If geolocation is unavailable, `private_range` does not grant access.
   - `filter`: Each endpoint has many capabilities
     + `SSL`: HTTPS available
     + `NOSSL`: HTTP available, and does not redirect to HTTPS when accessing repos
     + `V4`: IPv4 available (A record)
     + `V6`: IPv6 available (AAAA record)
-  - `range`: when `public` is `true`, the endpoint **prefers** these ranges more strongly, but other users may still use this endpoint; when `public` is `false`, CIDR entries still allow access, while `ISP` and `REGION` do not. `ISP` and `REGION` are only effective inside `private_range`. If no CIDR is declared, `private_range` may still allow access.
-    + COUNTRY: Must start with `COUNTRY`, then a colon, then [ISO country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Example: `COUNTRY:CN` or `COUNTRY:US`. Defaults to `CN`.
-    + REGION: Must start with `REGION`, then a colon, then province name (GB/T 2260-2007). Example: `REGION:BJ` (Beijing) or `REGION:SH` (Shanghai). Defaults to `BJ`.
-    + ISP: Must start with `ISP`, then a colon, then ISP name. Example: `ISP:CERNET` or `ISP:CHINANET`. Defaults to `CERNET`. All currently supported values are `CERNET`, `CSTNET`, `CHINANET`, `UNICOM` and `CMCC`.
-    + ASN (deprecated): Must start with `AS`. Example: `AS4538` and `AS13335`
+  - `range`: describes endpoint preferences and CIDR access rules. For a public endpoint, matching REGION, ISP, or CIDR entries improve its score, but non-matching clients may still use it. For a private endpoint, a matching CIDR grants access directly; REGION and ISP entries may affect scoring after the endpoint is eligible, but do not grant access. If no CIDR matches, `private_range` may still grant access.
+    + REGION: Must start with `REGION`, then a colon, then a province code (GB/T 2260-2007). Example: `REGION:BJ` (Beijing) or `REGION:SH` (Shanghai).
+    + ISP: Must start with `ISP`, then a colon, then an ISP name. Example: `ISP:CERNET` or `ISP:CHINANET`. Supported values are `CERNET`, `CSTNET`, `CHINANET`, `UNICOM` and `CMCC`.
     + CIDR: Example: `202.0.0.0/24` or `2001:da8::/32`
 * `abbrs`
   - Each value must exactly match the `mirror` tag written by mirrorz-monitor. Multiple monitor abbreviations may share the same endpoint configuration.
@@ -168,7 +166,7 @@ If a user does not match any range or match exactly the same in `mirrors` and `m
 #### On range when private endpoint
 
 ```json
-  {
+{
   "label": "zju",
   "public": false,
   "resolve": "mirrors.zju.edu.cn",
@@ -177,15 +175,12 @@ If a user does not match any range or match exactly the same in `mirrors` and `m
     ["REGION:ZJ"]
   ],
   "range": [
-    "COUNTRY:CN",
-    "REGION:ZJ",
-    "210.32.0.0/20",
-    "some other CIDR"
+    "210.32.0.0/20"
   ]
 }
 ```
-The site may use `private_range` to control access for users outside of its CIDR `range`. when `public` is `false`, CIDR matches are allowed directly. If `range` has no CIDR, access is decided by `private_range`. For users outside CIDRs in `range`, it will check if they match any group in `private_range`. If yes, then the request is allowed; otherwise denied.
-As follows, a user from Zhejiang will be possible to be redirected to this endpoint, while a user from Shanghai will be denied.
+
+The site may use `private_range` to control access for users outside of its CIDR `range`. When `public` is `false`, CIDR matches are allowed directly. For users outside those CIDRs, each `private_range` group is checked. In this example, clients in `210.32.0.0/20` are allowed directly, and other clients are allowed only when the IPDB identifies them as being in Zhejiang.
 
 #### TODO
 

--- a/pkg/geo/ipip.go
+++ b/pkg/geo/ipip.go
@@ -21,6 +21,11 @@ var DefaultCityInfo = CityInfo{
 
 var logger = logging.GetLogger("ipip")
 
+// Available reports whether an IP database has been loaded successfully.
+func Available() bool {
+	return db.Load() != nil
+}
+
 // LoadIPDB loads a new IPIP database.
 func LoadIPDB(filename string) error {
 	newdb, err := ipdb.NewCity(filename)

--- a/pkg/mirrorzdb/mirrorzdb.go
+++ b/pkg/mirrorzdb/mirrorzdb.go
@@ -89,15 +89,27 @@ func (e *Endpoint) UnmarshalJSON(data []byte) error {
 	// private_range
 	for _, ds := range j.PrivateRange {
 		pr := PrivateRange{}
+		seenRegion, seenISP := false, false
 		for _, d := range ds {
 			if region, ok := strings.CutPrefix(d, "REGION:"); ok {
+				if seenRegion {
+					logger.Warningf("duplicate REGION in private_range group: %s", d)
+				}
+				seenRegion = true
 				pr.Region = region
 			} else if isp, ok := strings.CutPrefix(d, "ISP:"); ok {
+				if seenISP {
+					logger.Warningf("duplicate ISP in private_range group: %s", d)
+				}
+				seenISP = true
 				pr.ISP = isp
 			} else {
-				// Unknown format
 				logger.Warningf("unknown private range format: %s", d)
 			}
+		}
+		if pr.Region == "" && pr.ISP == "" {
+			logger.Warningf("empty private_range group ignored")
+			continue
 		}
 		e.PrivateRanges = append(e.PrivateRanges, pr)
 	}

--- a/pkg/mirrorzdb/mirrorzdb.go
+++ b/pkg/mirrorzdb/mirrorzdb.go
@@ -15,29 +15,28 @@ import (
 
 var logger = logging.GetLogger("mirrorzdb")
 
+type PrivateRange struct {
+	Region string
+	ISP    string
+}
+
 type Endpoint struct {
 	Label   string
 	Resolve string
 	Public  bool
 	Filter  struct {
-		V4           bool
-		V4Only       bool
-		V6           bool
-		V6Only       bool
-		SSL          bool
-		NOSSL        bool
-		Special      []string
-		Region       []string
-		RegionOption bool
-		ISP          []string
-		ISPOption    bool
+		V4      bool
+		V4Only  bool
+		V6      bool
+		V6Only  bool
+		SSL     bool
+		NOSSL   bool
+		Special []string
 	}
-	RangeOption       bool
-	RangeRegion       []string
-	RangeRegionOption bool
-	RangeISP          []string
-	RangeISPOption    bool
-	RangeCIDR         []*net.IPNet
+	PrivateRanges []PrivateRange
+	RangeRegion   []string
+	RangeISP      []string
+	RangeCIDR     []*net.IPNet
 	// SiteLabel is the representative label of the site this endpoint
 	// belongs to (the first endpoint's label), set during Load. It is
 	// used so that `avoid<SiteLabel>` excludes the whole site.
@@ -46,11 +45,12 @@ type Endpoint struct {
 
 // endpointJSON is used to parse Endpoint from JSON.
 type endpointJSON struct {
-	Label   string   `json:"label"`
-	Resolve string   `json:"resolve"`
-	Public  bool     `json:"public"`
-	Filter  []string `json:"filter"`
-	Range   []string `json:"range"`
+	Label        string     `json:"label"`
+	Resolve      string     `json:"resolve"`
+	Public       bool       `json:"public"`
+	PrivateRange [][]string `json:"private_range"`
+	Filter       []string   `json:"filter"`
+	Range        []string   `json:"range"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
@@ -76,24 +76,30 @@ func (e *Endpoint) UnmarshalJSON(data []byte) error {
 		case "SSL":
 			e.Filter.SSL = true
 		default:
-			if region, ok := strings.CutPrefix(d, "REGION:"); ok {
-				e.Filter.Region = append(e.Filter.Region, region)
-			} else if isp, ok := strings.CutPrefix(d, "ISP:"); ok {
-				e.Filter.ISP = append(e.Filter.ISP, isp)
-			} else {
-				// TODO: more structured
-				e.Filter.Special = append(e.Filter.Special, d)
-			}
-
+			// TODO: more structured
+			e.Filter.Special = append(e.Filter.Special, d)
 		}
 	}
-	e.Filter.ISPOption = e.Filter.ISP != nil
-	e.Filter.RegionOption = e.Filter.Region != nil
 	if e.Filter.V4 && !e.Filter.V6 {
 		e.Filter.V4Only = true
 	}
 	if !e.Filter.V4 && e.Filter.V6 {
 		e.Filter.V6Only = true
+	}
+	// private_range
+	for _, ds := range j.PrivateRange {
+		pr := PrivateRange{}
+		for _, d := range ds {
+			if region, ok := strings.CutPrefix(d, "REGION:"); ok {
+				pr.Region = region
+			} else if isp, ok := strings.CutPrefix(d, "ISP:"); ok {
+				pr.ISP = isp
+			} else {
+				// Unknown format
+				logger.Warningf("unknown private range format: %s", d)
+			}
+		}
+		e.PrivateRanges = append(e.PrivateRanges, pr)
 	}
 	// Range
 	for _, d := range j.Range {
@@ -108,8 +114,6 @@ func (e *Endpoint) UnmarshalJSON(data []byte) error {
 			}
 		}
 	}
-	e.RangeISPOption = e.RangeISP != nil
-	e.RangeRegionOption = e.RangeRegion != nil
 	return nil
 }
 
@@ -126,6 +130,24 @@ func (e *Endpoint) Match(m requestmeta.RequestMeta) (reason string, ok bool) {
 
 	remoteIPv4 := m.IP.To4() != nil
 
+	// Special filters for private range
+	if !e.Public && e.MatchIPMask(m.IP) == 0 {
+		if e.PrivateRanges == nil {
+			return "ip not in cidr range", false
+		}
+		var status = false
+		for _, pr := range e.PrivateRanges {
+			if (pr.Region == "" || pr.Region == m.Region) &&
+				(pr.ISP == "" || MatchISP(pr.ISP, m.ISP)) {
+				status = true
+				break
+			}
+		}
+		if !status {
+			return "ip not in private range", false
+		}
+	}
+
 	switch {
 	case remoteIPv4 && !e.Filter.V4:
 		return "not v4 endpoint", false
@@ -139,54 +161,15 @@ func (e *Endpoint) Match(m requestmeta.RequestMeta) (reason string, ok bool) {
 		return "label v4only but endpoint not v4only", false
 	case m.V6Only() && !e.Filter.V6Only:
 		return "label v6only but endpoint not v6only", false
-	// Special filters for private site
-	case !e.Public && e.MatchIPMask(m.IP) == 0:
-		// Request must be included in filtered region AND ISP
-		if e.Filter.ISPOption || e.Filter.RegionOption {
-			if (e.Filter.RegionOption && !MatchRegion(m.Region, e.Filter.Region)) ||
-				(e.Filter.ISPOption && !MatchISPs(m.ISP, e.Filter.ISP)) {
-				return "ip not in filtered range", false
-			}
-			// Request should be included in filtered region OR ISP
-		} else if e.RangeISPOption || e.RangeRegionOption {
-			if (!e.RangeRegionOption || !MatchRegion(m.Region, e.RangeRegion)) &&
-				(!e.RangeISPOption || !MatchISPs(m.ISP, e.RangeISP)) {
-				return "ip not in private range", false
-			}
-		} else {
-			// This site may not define any region or isp rules
-			return "ip not in cidr range", false
-		}
-		return "OK", true
 	default:
 		return "OK", true
 	}
-}
-
-// MatchRegion reports if the given region is in the config of the endpoint
-func MatchRegion(region string, regions []string) bool {
-	for _, r := range regions {
-		if r == region {
-			return true
-		}
-	}
-	return false
 }
 
 // MatchISP reports if the given ISP is in the config of the endpoint.
 func MatchISP(isp string, isps []string) bool {
 	for _, r := range isps {
 		if r == isp {
-			return true
-		}
-	}
-	return false
-}
-
-// MatchISPs reports if the given ISP set intersects with the endpoint's preference.
-func MatchISPs(isps1 []string, isps2 []string) bool {
-	for _, isp := range isps1 {
-		if MatchISP(isp, isps2) {
 			return true
 		}
 	}

--- a/pkg/mirrorzdb/mirrorzdb.go
+++ b/pkg/mirrorzdb/mirrorzdb.go
@@ -87,29 +87,34 @@ func (e *Endpoint) UnmarshalJSON(data []byte) error {
 		e.Filter.V6Only = true
 	}
 	// private_range
-	for _, ds := range j.PrivateRange {
+	for groupIndex, ds := range j.PrivateRange {
+		if len(ds) == 0 {
+			return fmt.Errorf("private_range group %d is empty", groupIndex)
+		}
 		pr := PrivateRange{}
 		seenRegion, seenISP := false, false
 		for _, d := range ds {
 			if region, ok := strings.CutPrefix(d, "REGION:"); ok {
+				if region == "" {
+					return fmt.Errorf("private_range group %d has an empty REGION", groupIndex)
+				}
 				if seenRegion {
-					logger.Warningf("duplicate REGION in private_range group: %s", d)
+					return fmt.Errorf("private_range group %d has duplicate REGION conditions", groupIndex)
 				}
 				seenRegion = true
 				pr.Region = region
 			} else if isp, ok := strings.CutPrefix(d, "ISP:"); ok {
+				if isp == "" {
+					return fmt.Errorf("private_range group %d has an empty ISP", groupIndex)
+				}
 				if seenISP {
-					logger.Warningf("duplicate ISP in private_range group: %s", d)
+					return fmt.Errorf("private_range group %d has duplicate ISP conditions", groupIndex)
 				}
 				seenISP = true
 				pr.ISP = isp
 			} else {
-				logger.Warningf("unknown private range format: %s", d)
+				return fmt.Errorf("private_range group %d has unknown condition %q", groupIndex, d)
 			}
-		}
-		if pr.Region == "" && pr.ISP == "" {
-			logger.Warningf("empty private_range group ignored")
-			continue
 		}
 		e.PrivateRanges = append(e.PrivateRanges, pr)
 	}
@@ -144,10 +149,16 @@ func (e *Endpoint) Match(m requestmeta.RequestMeta) (reason string, ok bool) {
 
 	// Special filters for private range
 	if !e.Public && e.MatchIPMask(m.IP) == 0 {
-		if e.PrivateRanges == nil {
-			return "ip not in cidr range", false
+		if len(e.PrivateRanges) == 0 {
+			if len(e.RangeCIDR) == 0 {
+				return "private endpoint without access range (disabled)", false
+			}
+			return "ip not in private cidr range", false
 		}
-		var status = false
+		if !m.GeoKnown {
+			return "geolocation unavailable for private range", false
+		}
+		status := false
 		for _, pr := range e.PrivateRanges {
 			if (pr.Region == "" || pr.Region == m.Region) &&
 				(pr.ISP == "" || MatchISP(pr.ISP, m.ISP)) {

--- a/pkg/mirrorzdb/mirrorzdb.go
+++ b/pkg/mirrorzdb/mirrorzdb.go
@@ -20,17 +20,24 @@ type Endpoint struct {
 	Resolve string
 	Public  bool
 	Filter  struct {
-		V4      bool
-		V4Only  bool
-		V6      bool
-		V6Only  bool
-		SSL     bool
-		NOSSL   bool
-		Special []string
+		V4           bool
+		V4Only       bool
+		V6           bool
+		V6Only       bool
+		SSL          bool
+		NOSSL        bool
+		Special      []string
+		Region       []string
+		RegionOption bool
+		ISP          []string
+		ISPOption    bool
 	}
-	RangeRegion []string
-	RangeISP    []string
-	RangeCIDR   []*net.IPNet
+	RangeOption       bool
+	RangeRegion       []string
+	RangeRegionOption bool
+	RangeISP          []string
+	RangeISPOption    bool
+	RangeCIDR         []*net.IPNet
 	// SiteLabel is the representative label of the site this endpoint
 	// belongs to (the first endpoint's label), set during Load. It is
 	// used so that `avoid<SiteLabel>` excludes the whole site.
@@ -69,10 +76,19 @@ func (e *Endpoint) UnmarshalJSON(data []byte) error {
 		case "SSL":
 			e.Filter.SSL = true
 		default:
-			// TODO: more structured
-			e.Filter.Special = append(e.Filter.Special, d)
+			if region, ok := strings.CutPrefix(d, "REGION:"); ok {
+				e.Filter.Region = append(e.Filter.Region, region)
+			} else if isp, ok := strings.CutPrefix(d, "ISP:"); ok {
+				e.Filter.ISP = append(e.Filter.ISP, isp)
+			} else {
+				// TODO: more structured
+				e.Filter.Special = append(e.Filter.Special, d)
+			}
+
 		}
 	}
+	e.Filter.ISPOption = e.Filter.ISP != nil
+	e.Filter.RegionOption = e.Filter.Region != nil
 	if e.Filter.V4 && !e.Filter.V6 {
 		e.Filter.V4Only = true
 	}
@@ -92,6 +108,8 @@ func (e *Endpoint) UnmarshalJSON(data []byte) error {
 			}
 		}
 	}
+	e.RangeISPOption = e.RangeISP != nil
+	e.RangeRegionOption = e.RangeRegion != nil
 	return nil
 }
 
@@ -121,18 +139,43 @@ func (e *Endpoint) Match(m requestmeta.RequestMeta) (reason string, ok bool) {
 		return "label v4only but endpoint not v4only", false
 	case m.V6Only() && !e.Filter.V6Only:
 		return "label v6only but endpoint not v6only", false
-	case !e.Public && len(e.RangeCIDR) == 0:
-		return "private endpoint without cidr range (disabled)", false
+	// Special filters for private site
 	case !e.Public && e.MatchIPMask(m.IP) == 0:
-		return "ip not in private cidr range", false
+		// Request must be included in filtered region AND ISP
+		if e.Filter.ISPOption || e.Filter.RegionOption {
+			if (e.Filter.RegionOption && !MatchRegion(m.Region, e.Filter.Region)) ||
+				(e.Filter.ISPOption && !MatchISPs(m.ISP, e.Filter.ISP)) {
+				return "ip not in filtered range", false
+			}
+			// Request should be included in filtered region OR ISP
+		} else if e.RangeISPOption || e.RangeRegionOption {
+			if (!e.RangeRegionOption || !MatchRegion(m.Region, e.RangeRegion)) &&
+				(!e.RangeISPOption || !MatchISPs(m.ISP, e.RangeISP)) {
+				return "ip not in private range", false
+			}
+		} else {
+			// This site may not define any region or isp rules
+			return "ip not in cidr range", false
+		}
+		return "OK", true
 	default:
 		return "OK", true
 	}
 }
 
-// MatchISP reports if the given ISP is preferred by the endpoint.
-func (e *Endpoint) MatchISP(isp string) bool {
-	for _, r := range e.RangeISP {
+// MatchRegion reports if the given region is in the config of the endpoint
+func MatchRegion(region string, regions []string) bool {
+	for _, r := range regions {
+		if r == region {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchISP reports if the given ISP is in the config of the endpoint.
+func MatchISP(isp string, isps []string) bool {
+	for _, r := range isps {
 		if r == isp {
 			return true
 		}
@@ -141,9 +184,9 @@ func (e *Endpoint) MatchISP(isp string) bool {
 }
 
 // MatchISPs reports if the given ISP set intersects with the endpoint's preference.
-func (e *Endpoint) MatchISPs(isps []string) bool {
-	for _, isp := range isps {
-		if e.MatchISP(isp) {
+func MatchISPs(isps1 []string, isps2 []string) bool {
+	for _, isp := range isps1 {
+		if MatchISP(isp, isps2) {
 			return true
 		}
 	}

--- a/pkg/mirrorzdb/mirrorzdb_test.go
+++ b/pkg/mirrorzdb/mirrorzdb_test.go
@@ -1,6 +1,7 @@
 package mirrorzdb
 
 import (
+	"encoding/json"
 	"net"
 	"testing"
 
@@ -82,4 +83,58 @@ func TestMatchPrivateEndpoint(t *testing.T) {
 	reason, ok = e.Match(meta)
 	as.True(ok)
 	as.Equal("OK", reason)
+}
+
+func TestMatchPrivateRangeRequiresKnownGeo(t *testing.T) {
+	e := v4HTTPEndpoint()
+	e.PrivateRanges = []PrivateRange{{Region: "ZJ", ISP: "CERNET"}}
+
+	meta := requestmeta.RequestMeta{
+		IP:       net.ParseIP("192.0.2.1"),
+		Scheme:   "http",
+		Region:   "ZJ",
+		ISP:      []string{"CERNET"},
+		GeoKnown: false,
+	}
+	reason, ok := e.Match(meta)
+	assert.False(t, ok)
+	assert.Contains(t, reason, "geolocation unavailable")
+
+	meta.GeoKnown = true
+	reason, ok = e.Match(meta)
+	assert.True(t, ok, reason)
+
+	meta.ISP = []string{"CHINANET"}
+	reason, ok = e.Match(meta)
+	assert.False(t, ok)
+	assert.Contains(t, reason, "not in private range")
+}
+
+func TestPrivateRangeDoesNotRestrictCIDRMatch(t *testing.T) {
+	e := v4HTTPEndpoint()
+	e.RangeCIDR = []*net.IPNet{mustCIDR(t, "192.0.2.0/24")}
+	e.PrivateRanges = []PrivateRange{{Region: "ZJ"}}
+
+	reason, ok := e.Match(requestmeta.RequestMeta{
+		IP:     net.ParseIP("192.0.2.1"),
+		Scheme: "http",
+	})
+	assert.True(t, ok, reason)
+}
+
+func TestRejectInvalidPrivateRange(t *testing.T) {
+	tests := map[string]string{
+		"empty group":       `{"private_range":[[]]}`,
+		"unknown condition": `{"private_range":[["IPS:CERNET"]]}`,
+		"empty region":      `{"private_range":[["REGION:"]]}`,
+		"empty isp":         `{"private_range":[["ISP:"]]}`,
+		"duplicate region":  `{"private_range":[["REGION:ZJ","REGION:SH"]]}`,
+		"duplicate isp":     `{"private_range":[["ISP:CERNET","ISP:CHINANET"]]}`,
+	}
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			var endpoint Endpoint
+			assert.Error(t, json.Unmarshal([]byte(data), &endpoint))
+		})
+	}
 }

--- a/pkg/requestmeta/requestmeta.go
+++ b/pkg/requestmeta/requestmeta.go
@@ -16,9 +16,12 @@ type RequestMeta struct {
 
 	Scheme string
 	IP     net.IP
-	Region string
-	ISP    []string
-	Labels []string
+	// GeoKnown indicates that Region and ISP came from a loaded IP database,
+	// rather than the placeholder returned by geo.Lookup without one.
+	GeoKnown bool
+	Region   string
+	ISP      []string
+	Labels   []string
 }
 
 const ApiPrefix = "/api/"
@@ -43,7 +46,8 @@ func (p *Parser) parseCommon(r *http.Request, meta *RequestMeta) {
 	ipinfo, err := geo.Lookup(meta.IP.String())
 	if err != nil {
 		parserLogger.Warningf("IPDB lookup failed for %s: %v\n", meta.IP, err)
-	} else {
+	} else if ipinfo != nil {
+		meta.GeoKnown = geo.Available()
 		meta.Region = geo.NameToCode(ipinfo.RegionName)
 		for _, line := range strings.Split(ipinfo.Line, "/") {
 			if isp := geo.ISPNameToCode(line); isp != "" {
@@ -63,7 +67,7 @@ func (m *RequestMeta) V6Only() bool {
 	return l != 0 && m.Labels[l-1] == "6"
 }
 
-func (m *RequestMeta) String() string {
+func (m RequestMeta) String() string {
 	return fmt.Sprintf("%s:%s (%v, %s/%s) %v", m.Scheme, m.CName, m.IP, m.Region, m.ISP, m.Labels)
 }
 

--- a/pkg/scoring/eval.go
+++ b/pkg/scoring/eval.go
@@ -26,7 +26,7 @@ func Eval(e mirrorzdb.Endpoint, m requestmeta.RequestMeta) (score Score) {
 	}
 
 	for _, isp := range m.ISP {
-		if e.MatchISP(isp) {
+		if mirrorzdb.MatchISP(isp, e.RangeISP) {
 			score.ISP = 1
 		}
 	}


### PR DESCRIPTION
配置文件中，当public为false时，
用户需要满足三个条件之一才能访问
1.同时满足filter定义的region与isp
2.满足range定义的region或isp
3.匹配cidr