### PR TITLE
fix: correct resolve cache GC ticker interval

### DIFF
--- a/pkg/caching/cache.go
+++ b/pkg/caching/cache.go
@@ -102,7 +102,7 @@ func (c *ResolveCache) StartGCTicker() {
 	if c.ticker != nil {
 		return
 	}
-	c.ticker = time.NewTicker(time.Second * time.Duration(c.ttl))
+	c.ticker = time.NewTicker(c.ttl)
 	go c.gcTicker(c.ticker.C)
 }
 

--- a/pkg/caching/cache_test.go
+++ b/pkg/caching/cache_test.go
@@ -24,3 +24,23 @@ func TestResolveCache(t *testing.T) {
 	as.Equal(r.start, r2.start)
 	as.Equal(StatusStale, status)
 }
+
+func TestStartGCTickerLongTTL(t *testing.T) {
+	// 600s used to overflow the ticker interval computation and panic.
+	c := NewResolveCache(600 * time.Second)
+	c.StartGCTicker()
+	c.StopGCTicker()
+}
+
+func TestGCTickerRemovesExpiredEntries(t *testing.T) {
+	as := assert.New(t)
+	c := NewResolveCache(10 * time.Millisecond)
+	c.StartGCTicker()
+	defer c.StopGCTicker()
+
+	c.Store("a", Resolved{})
+	as.Eventually(func() bool {
+		_, status := c.Load("a")
+		return status == StatusNone
+	}, time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
在 `pkg/caching/cache.go` 里，`ResolveCache` 的 `ttl` 字段本身就是 `time.Duration`
（即 [`server.go:68`](pkg/server/server.go#L68) 传入 `time.Duration(config.CacheTime) * time.Second` ）

而 `StartGCTicker` 里又乘了一次 `time.Second`，等于把间隔放大 10^9 倍。

这就导致两种情况：

1. GC 永不运行导致缓存无界增长。`cache-time` 为 5/60/300/3600 时，实际 GC 间隔约 92~158 年。每个唯一的 `IP+cname+scheme+labels` 组合永驻内存，且解析失败也会写缓存（`resolve.go` 无条件 `Store`），任意路径扫描都产生永久条目；只能靠 `SIGWINCH` 或重启缓解
2. 部分合法配置直接无法启动。`cache-time` 为 600/1800/86400 时乘积溢出 int64 为负值，`time.NewTicker` panic，启动即崩溃且 panic 信息不提示与 cache-time 相关。

所以给它直接改成了 `c.ticker = time.NewTicker(c.ttl)`，恢复了正常预期的行为（