### PR TITLE
fix: choose the first endpoint on tied scores

### DIFF
--- a/pkg/scoring/score.go
+++ b/pkg/scoring/score.go
@@ -66,9 +66,9 @@ func (l Score) Less(r Score) bool {
 	} else if r.Delta < 0 && l.Delta > 0 {
 		return false
 	} else if r.Delta > 0 && l.Delta > 0 {
-		return l.Delta <= r.Delta
+		return l.Delta < r.Delta
 	} else {
-		return r.Delta <= l.Delta
+		return r.Delta < l.Delta
 	}
 }
 
@@ -126,7 +126,7 @@ func (s Scores) Swap(l, r int) { s[l], s[r] = s[r], s[l] }
 
 // Sort sorts the scores in place.
 func (s Scores) Sort() {
-	sort.Sort(s)
+	sort.Stable(s)
 }
 
 func (scores Scores) RandomRange(r int) Score {

--- a/pkg/scoring/score_test.go
+++ b/pkg/scoring/score_test.go
@@ -3,6 +3,7 @@ package scoring
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math"
 	"testing"
 
@@ -63,4 +64,26 @@ func TestUnknownScoreIsFallback(t *testing.T) {
 
 	assert.True(t, normal.Less(preferredByLocation))
 	assert.False(t, preferredByLocation.Less(normal))
+}
+
+func TestLessEqualScores(t *testing.T) {
+	as := assert.New(t)
+	synced := Score{Geo: 900, Delta: -70000}
+	as.False(synced.Less(synced))
+	proxy := Score{Geo: 900, Delta: 1000}
+	as.False(proxy.Less(proxy))
+}
+
+func TestSortKeepsEqualScoreOrder(t *testing.T) {
+	as := assert.New(t)
+	for _, n := range []int{6, 20} {
+		scores := make(Scores, 0, n)
+		for i := 0; i < n; i++ {
+			scores = append(scores, Score{Geo: 900, Delta: -70000, Label: fmt.Sprintf("e%02d", i)})
+		}
+		scores.Sort()
+		for i, score := range scores {
+			as.Equal(fmt.Sprintf("e%02d", i), score.Label)
+		}
+	}
 }


### PR DESCRIPTION
`Score.Less` 在两个分数完全相等时返回 `true`（delta 分支用了 <=），即 `Less(a,b)` 与 `Less(b,a)` 同时为真，不满足 `sort.Interface` 要求的严格弱序，导致排序结果未定义。

实际表现有两个：并列组 n<12 时走 Go 的插入排序，「相等也算小于」使元素一路冒泡到最前，并列组被倒序。n>12 pdqsort，并列组被打乱，`Scores.Sort()` 用的是不稳定的 sort.Sort，即便比较器合法，全局排序仍会打乱并列端点的先后。

但 readme 里写了 `The first endpoint is the default endpoint. If all the endpoints have the same preference, we choose the first one.`，由于同站所有端点共享同一个监控 delta，只要 REGION/ISP/CIDR/label 不产生区分，那么站内并列是结构性的、极常见的

这就导致通用流量被导向站方的专线 vhost。本地部署测试，使用安徽客户端请求 archlinux，USTC 六个并列端点按配置倒序排列，302 目标落在 `cmcc.mirrors.ustc.edu.cn` / `unicom.mirrors.ustc.edu.cn` 这类为特定运营商准备的端点上，而非文档所说的默认端点。其它通用+专用的多端点镜像站可能也会出现这个情况

也会导致并列时选中谁取决于排序实现内部；`/api/scoring` 的输出序、APT mirrorlist 的 `priority:1` 归属同样任意，且粘性缓存会把用户钉在任意选中的端点上。

