### PR TITLE
fix: bypass resolve cache for trace requests

### DIFF
--- a/pkg/server/resolve.go
+++ b/pkg/server/resolve.go
@@ -81,7 +81,7 @@ func (s *Server) Resolve(ctx context.Context, meta requestmeta.RequestMeta) (url
 	keyResolved, cacheStatus := s.resolved.Load(key)
 
 	// all valid, use cached result
-	if cacheStatus == caching.StatusFresh {
+	if cacheStatus == caching.StatusFresh && !tracer.Enabled() {
 		// update timestamp
 		s.resolved.Store(key, keyResolved)
 		url = keyResolved.Url

--- a/pkg/server/resolve_test.go
+++ b/pkg/server/resolve_test.go
@@ -268,3 +268,48 @@ func TestScoringAPIIncludesEveryConfiguredAbbr(t *testing.T) {
 	require.Len(t, response.Scores, 2)
 	assert.ElementsMatch(t, []string{"TUNA.NANO", "TUNA.NEO"}, []string{response.Scores[0].Abbr, response.Scores[1].Abbr})
 }
+
+func TestTraceBypassesFreshCache(t *testing.T) {
+	influx := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/query", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"series":[{"name":"repo","tags":{"mirror":"TUNA.NANO","url":"/archlinux"},"columns":["time","value","disable"],"values":[["2026-08-25T00:00:00Z",-1,false]]}]}]}`))
+	}))
+	defer influx.Close()
+
+	dir := t.TempDir()
+	config := `{"abbrs":["TUNA.NANO","TUNA.NEO"],"endpoints":[{"label":"tuna","resolve":"mirrors.tuna.tsinghua.edu.cn","public":true,"filter":["V4","V6","SSL","NOSSL"]}]}`
+	writeSiteConfig(t, dir, "tuna", config)
+
+	s := NewServer(Config{
+		InfluxDB:          influxdb.Config{URL: influx.URL, Database: "mirrorz"},
+		MirrorZDDirectory: dir,
+		DomainLength:      5,
+		CacheTime:         300,
+	})
+	require.NoError(t, s.LoadMirrorZD())
+
+	get := func(target string) *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodGet, target, nil)
+		r.Header.Set("X-Forwarded-Proto", "https")
+		r.Header.Set("X-Forwarded-Host", "mirrors.cernet.edu.cn")
+		r.Header.Set("X-Real-IP", "192.0.2.1")
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, r)
+		return w
+	}
+
+	// populate the cache
+	first := get("https://mirrors.cernet.edu.cn/archlinux/")
+	require.Equal(t, http.StatusFound, first.Code)
+
+	// a trace request on a fresh cache entry must still show the scoring detail
+	traced := get("https://mirrors.cernet.edu.cn/archlinux/?trace=1")
+	require.Equal(t, http.StatusOK, traced.Code)
+	assert.Contains(t, traced.Body.String(), "score 0:")
+
+	// regular requests keep being served from the cache
+	second := get("https://mirrors.cernet.edu.cn/archlinux/")
+	assert.Equal(t, http.StatusFound, second.Code)
+	assert.Equal(t, "https://mirrors.tuna.tsinghua.edu.cn/archlinux/", second.Header().Get("Location"))
+}

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -20,6 +20,7 @@ type Tracer interface {
 	io.WriterTo
 	fmt.Stringer
 	Printf(format string, args ...any)
+	Enabled() bool
 }
 
 // NewTracer returns a new Tracer.
@@ -53,6 +54,11 @@ func (t *bufTracer) String() string {
 	return t.b.String()
 }
 
+// Enabled implements the Tracer interface.
+func (t *bufTracer) Enabled() bool {
+	return true
+}
+
 // WriteTo implements the io.WriterTo interface.
 func (t *bufTracer) WriteTo(w io.Writer) (n int64, err error) {
 	N, err := io.WriteString(w, t.b.String())
@@ -68,6 +74,11 @@ func (t *nopTracer) Printf(format string, args ...any) {}
 // String implements the fmt.Stringer interface.
 func (t *nopTracer) String() string {
 	return ""
+}
+
+// Enabled implements the Tracer interface.
+func (t *nopTracer) Enabled() bool {
+	return false
 }
 
 // WriteTo implements the io.WriterTo interface.

--- a/pkg/tracing/tracer_test.go
+++ b/pkg/tracing/tracer_test.go
@@ -10,6 +10,7 @@ import (
 func TestTracer(t *testing.T) {
 	as := assert.New(t)
 	tr := NewTracer(true)
+	as.True(tr.Enabled())
 
 	tr.Printf("ta%sky", "o")
 	as.Equal(tr.String(), "taoky")
@@ -28,6 +29,7 @@ func TestTracer(t *testing.T) {
 func TestNopTracer(t *testing.T) {
 	as := assert.New(t)
 	tr := NewTracer(false)
+	as.False(tr.Enabled())
 
 	tr.Printf("ta%sky", "o")
 	as.Equal(tr.String(), "")


### PR DESCRIPTION
`Resolve` 在缓存 `StatusFresh` 时提前返回（resolve.go:84-90），此时 tracer 里只有 Labels/IP/Scheme 三行头加一行 `C: <url>`，返回的是四行存根。阈值计算、逐站逐端点的淘汰原因、六维分数、最终排序等打分明细全部缺失。

触发条件：同一缓存键（IP+cname+scheme+labels）在 `cache-time` 窗口内重复请求即触发；且第一条 trace 请求自己就会填充缓存，导致两次跑同一个 curl 进行对比一定会触发这个问题，窗口按条目创建时间计算，重试无法解套，样例配置下存根状态最长持续 300s，唯一直接解法是 SIGWINCH 清空全部缓存。

解决方法：trace 请求跳过 Fresh 短路，始终执行完整打分，末尾既有的无条件 `Store` 会用新结果刷新缓存；非 trace 则无影响。