### PR TITLE
fix: exit nonzero on HTTP server error

### DIFF
--- a/302.go
+++ b/302.go
@@ -106,6 +106,7 @@ func main() {
 	s.StartResolvedTicker()
 
 	logger.Infof("Starting HTTP server on %s\n", config.HTTPBindAddress)
-	logger.Errorf("HTTP Server error: %v\n", http.ListenAndServe(config.HTTPBindAddress, s))
+	err = http.ListenAndServe(config.HTTPBindAddress, s)
+	logger.Errorf("HTTP Server error: %v\n", err)
 	os.Exit(1)
 }

--- a/302.go
+++ b/302.go
@@ -107,4 +107,5 @@ func main() {
 
 	logger.Infof("Starting HTTP server on %s\n", config.HTTPBindAddress)
 	logger.Errorf("HTTP Server error: %v\n", http.ListenAndServe(config.HTTPBindAddress, s))
+	os.Exit(1)
 }

--- a/etc/mirrorzd.service
+++ b/etc/mirrorzd.service
@@ -6,6 +6,7 @@ After=network-online.target
 [Service]
 Type=exec
 Restart=on-failure
+RestartSec=2
 User=mirrorz
 ExecStart=/usr/local/sbin/mirrorzd -config /etc/mirrorzd/config.yml
 ExecReload=/bin/kill -HUP $MAINPID

--- a/etc/mirrorzd.service
+++ b/etc/mirrorzd.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=mirrorz-302 server
+Wants=network-online.target
 After=network-online.target
 
 [Service]
 Type=exec
+Restart=on-failure
 User=mirrorz
 ExecStart=/usr/local/sbin/mirrorzd -config /etc/mirrorzd/config.yml
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
修复了监听失败后进程以退出码 0 结束和 systemd 单元既不重启也没把网络依赖拉起来的问题。

这可能导致在 bind 端口失败时得到一个退出码 0，导致不进入 failed 状态，`OnFailure=` 不触发、按 failed 告警的监控全部沉默，只能手工发现后进行处理

修改后 bind 失败退出码为 1。`Restart=on-failure` 使瞬时故障（如网络还没就绪时）自动重启试图自愈，持续故障则单元进入 failed 状态